### PR TITLE
Fix circle timer

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,6 @@
 		<link rel="stylesheet" href="styles/index.css">
 		<script src="js/circleCtrl.js"></script>
 		<script src="js/main.js"></script>
-		<script src="../bower_components/jquery-circle-progress/dist/circle-progress.js"></script>
 	</head>
 	<body>
 		<div class="window">

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="styles/index.css">
 		<script src="js/circleCtrl.js"></script>
 		<script src="js/main.js"></script>
+		<script src="../bower_components/jquery-circle-progress/dist/circle-progress.js"></script>
 	</head>
 	<body>
 		<div class="window">

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -8,7 +8,6 @@ const timeFormat = new hrt('%mm%:%ss%');
 const retina = require('retinajs');
 
 window.$ = window.jQuery = require('jquery');
-require("../bower_components/jquery-circle-progress/dist/circle-progress.js")()
 
 var settingsWindow = createWindow();
 var circleTimer;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -8,6 +8,7 @@ const timeFormat = new hrt('%mm%:%ss%');
 const retina = require('retinajs');
 
 window.$ = window.jQuery = require('jquery');
+require("../bower_components/jquery-circle-progress/dist/circle-progress.js")()
 
 var settingsWindow = createWindow();
 var circleTimer;


### PR DESCRIPTION
First off, great project.

When I downloaded it today, I noticed that there was no circle progress in the timer. Looking a little deeper, I noticed that circleProgress wasn't available on the jQuery element. It looks like the same problem that prevents jQuery from being used as a direct script load, jquery-circle-progress checks if 'module' is defined and then provides a function that eventually registers the plugin with jQuery instead of simply registering.

So, the fix here is simply to require it in main.js and execute the function returned.