### PR TITLE
fix: increase settings window height

### DIFF
--- a/src-tauri/src/ui/window.rs
+++ b/src-tauri/src/ui/window.rs
@@ -73,7 +73,7 @@ pub fn setup_settings_window<R: Runtime>(app_handle: &AppHandle<R>) -> Result<Wi
   .title("Settings")
   .visible(false)
   .resizable(false)
-  .inner_size(350., 298.)
+  .inner_size(350., 310.)
   .focused(true)
   .skip_taskbar(true)
   .build()?;


### PR DESCRIPTION
Prevents overflow, apparently release settings build from Github looks differently from local dev/release build.